### PR TITLE
Move file handling to extension

### DIFF
--- a/lib/middleman-inline_svg/inline_svg.rb
+++ b/lib/middleman-inline_svg/inline_svg.rb
@@ -1,16 +1,16 @@
 require "nokogiri"
 
 class InlineSVG
-  attr_reader :file_name, :options, :title
+  attr_reader :file, :options, :title
 
-  def initialize(file_name, options = {})
-    @file_name = file_name
+  def initialize(file, options = {})
+    @file = file
     @title = options.delete(:title)
     @options = options
   end
 
   def to_html
-    doc = asset_doc(file_name)
+    doc = asset_doc(file)
     svg = doc.at_css("svg")
 
     if title
@@ -34,9 +34,7 @@ class InlineSVG
     svg.prepend_child(title_node)
   end
 
-  def asset_doc(file_name)
-    File.open(file_name) do |f|
-      ::Nokogiri::XML(f)
-    end
+  def asset_doc(file)
+    ::Nokogiri::XML(file)
   end
 end

--- a/lib/middleman-inline_svg/middleman-inline_svg.rb
+++ b/lib/middleman-inline_svg/middleman-inline_svg.rb
@@ -18,6 +18,10 @@ class MiddlemanInlineSVG < ::Middleman::Extension
   private
 
   def asset_file(file_name)
-    File.join(app.config[:source], app.config[:images_dir], file_name)
+    File.open(File.join(file_path, file_name))
+  end
+
+  def file_path
+    File.join(app.config[:source], app.config[:images_dir])
   end
 end

--- a/test/middleman-inline_svg/inline_svg_test.rb
+++ b/test/middleman-inline_svg/inline_svg_test.rb
@@ -5,7 +5,7 @@ require_relative "../../lib/middleman-inline_svg/inline_svg"
 class TestInlineSVG < Minitest::Test
   def test_it_adds_a_title
     new_svg = InlineSVG.new(
-      "test/fixtures/circle.svg",
+      File.open("test/fixtures/circle.svg"),
       title: "Circle",
     ).to_html
 
@@ -20,7 +20,7 @@ class TestInlineSVG < Minitest::Test
 
   def test_it_adds_a_class
     new_svg = InlineSVG.new(
-      "test/fixtures/circle.svg",
+      File.open("test/fixtures/circle.svg"),
       class: "circle",
     ).to_html
 
@@ -35,7 +35,7 @@ class TestInlineSVG < Minitest::Test
 
   def test_it_adds_multiple_attributes
     new_svg = InlineSVG.new(
-      "test/fixtures/circle.svg",
+      File.open("test/fixtures/circle.svg"),
       class: "circle",
       role: "img",
       id: "circle",
@@ -52,7 +52,7 @@ class TestInlineSVG < Minitest::Test
 
   def test_it_transforms_attribute_names
     new_svg = InlineSVG.new(
-      "test/fixtures/circle.svg",
+      File.open("test/fixtures/circle.svg"),
       aria_hidden: true,
     ).to_html
 


### PR DESCRIPTION
Abstracting this out of the InlineSVG class makes it more flexible. This means we can use something like `OpenURI` to pass in a remote SVG via a URL or FTP address.